### PR TITLE
implementing refresh token along with access token

### DIFF
--- a/JWTtoken.py
+++ b/JWTtoken.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from fastapi import Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError, jwt
 import database
@@ -9,6 +9,8 @@ from sqlalchemy.orm import Session
 import os
 from dotenv import load_dotenv
 
+import routers
+
 
 load_dotenv()
 
@@ -16,6 +18,8 @@ SECRET_KEY = os.getenv("JWTtoken")
 # Algorithm used for JWT token encoding and decoding
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 1440
+REFRESH_TOKEN_EXPIRE_DAYS = 30
+REFRESH_SECRET_KEY = os.getenv("REFRESH_KEY")
 
 # OAuth2 password bearer scheme for token authentication
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="login")
@@ -28,6 +32,14 @@ def create_access_token(data: dict):
 
     # Encode the data into a JWT token using the secret key and algorithm
     encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+
+def create_refresh_token(data: dict):
+    to_encode = data.copy()
+    expire = datetime.utcnow() + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, REFRESH_SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
 
 

--- a/routers/authentication.py
+++ b/routers/authentication.py
@@ -2,17 +2,28 @@ from fastapi import APIRouter, Depends, status, HTTPException
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session
 from hashing import Hashing
-import database, models, JWTtoken
-from JWTtoken import get_current_user
+import database, models
+from JWTtoken import get_current_user, create_refresh_token, create_access_token
+from jose import JWTError, jwt
+import os
+
 
 router = APIRouter(tags=["Authentication"])
 
 
+SECRET_KEY = os.getenv("JWTtoken")
+REFRESH_SECRET_KEY = os.getenv("REFRESH_KEY")
+ALGORITHM = "HS256"
+REFRESH_TOKEN_EXPIRE_DAYS = 30
+
+
+# Login
 @router.post("/login")
 def login(
     authentication: OAuth2PasswordRequestForm = Depends(),
     db: Session = Depends(database.get_db),
 ):
+    # Check if the user exists
     user = (
         db.query(models.User)
         .filter(models.User.username == authentication.username)
@@ -22,15 +33,19 @@ def login(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=f"Invalid username"
         )
+    # Check if the password is correct
     if not Hashing.verify(user.hashed_password, authentication.password):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=f"Invalid Password"
         )
+    # Check if the account is verified
     if user.is_verified != True:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Account Not Verified"
         )
-    access_token = JWTtoken.create_access_token(
+
+    # Generate access token
+    access_token = create_access_token(
         data={
             "sub": user.username,
             "id": user.id,
@@ -39,9 +54,45 @@ def login(
             "is_hospital_admin": user.is_hospital_admin,
         }
     )
-    return {"access_token": access_token, "token_type": "bearer"}
+
+    # Generate refresh token
+    refresh_token = create_refresh_token(
+        data={
+            "sub": user.username,
+            "id": user.id,
+        }
+    )
+
+    # Return both tokens
+    return {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "token_type": "bearer",
+    }
 
 
+# Route to refresh access token
+@router.post("/refresh-token")
+def refresh_token(refresh_token: str):
+    try:
+        # Decode the refresh token
+        payload = jwt.decode(refresh_token, REFRESH_SECRET_KEY, algorithms=[ALGORITHM])
+        username: str = payload.get("sub")
+        id: int = payload.get("id")
+        if username is None or id is None:
+            raise get_user_exception()
+
+        # Create a new access token
+        new_access_token = create_access_token({"sub": username, "id": id})
+        return {"access_token": new_access_token, "token_type": "bearer"}
+    except JWTError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid refresh token",
+        )
+
+
+# Home route for authenticated users
 @router.get("/home")
 async def home(current_user: models.User = Depends(get_current_user)):
     return {


### PR DESCRIPTION
### **Changes**

1. Added refresh token generation and /refresh-token endpoint to refresh access tokens.
2. Set access token to expire in 24 hours, refresh token in 30 days.
3. Updated .env to include REFRESH_KEY for securing refresh tokens.
4. Improved error handling for invalid/expired tokens.